### PR TITLE
Aggiunto service per blocco rss

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         'plone.restapi',
         'plone.app.dexterity',
         'design.plone.contenttypes',
+        'redturtle.rssservice',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
Il blocco rss è installato di default nel tema volto, quindi serve questo di default, direi. Giusto?