### PR TITLE
Sistemati alcuni tipi aggiungibili nella struttura automatica

### DIFF
--- a/src/design/plone/policy/tests/test_initial_structure.py
+++ b/src/design/plone/policy/tests/test_initial_structure.py
@@ -227,4 +227,3 @@ class TestInitialStructureCreation(unittest.TestCase):
         self.assertEqual(
             folder.locally_allowed_types, ("Document", "Pagina Argomento")
         )
-

--- a/src/design/plone/policy/tests/test_initial_structure.py
+++ b/src/design/plone/policy/tests/test_initial_structure.py
@@ -65,7 +65,7 @@ class TestInitialStructureCreation(unittest.TestCase):
         )
         self.assertEqual(
             amministrazione["personale-amministrativo"].locally_allowed_types,
-            ("Persona",),
+            ("Document", "Persona"),
         )
 
         self.assertEqual(
@@ -76,7 +76,7 @@ class TestInitialStructureCreation(unittest.TestCase):
         )
         self.assertEqual(
             amministrazione["organi-di-governo"].locally_allowed_types,
-            ("UnitaOrganizzativa",),
+            ("Document", "UnitaOrganizzativa"),
         )
 
         self.assertEqual(
@@ -87,14 +87,14 @@ class TestInitialStructureCreation(unittest.TestCase):
         )
         self.assertEqual(
             amministrazione["aree-amministrative"].locally_allowed_types,
-            ("UnitaOrganizzativa",),
+            ("Document", "UnitaOrganizzativa"),
         )
 
         self.assertEqual(amministrazione["uffici"].portal_type, "Document")
         self.assertEqual(amministrazione["uffici"].constrain_types_mode, 1)
         self.assertEqual(
             amministrazione["uffici"].locally_allowed_types,
-            ("UnitaOrganizzativa",),
+            ("Document", "UnitaOrganizzativa"),
         )
 
         self.assertEqual(
@@ -105,13 +105,14 @@ class TestInitialStructureCreation(unittest.TestCase):
         )
         self.assertEqual(
             amministrazione["enti-e-fondazioni"].locally_allowed_types,
-            ("UnitaOrganizzativa",),
+            ("Document", "UnitaOrganizzativa"),
         )
 
         self.assertEqual(amministrazione["luoghi"].portal_type, "Document")
         self.assertEqual(amministrazione["luoghi"].constrain_types_mode, 1)
         self.assertEqual(
-            amministrazione["luoghi"].locally_allowed_types, ("Venue",)
+            amministrazione["luoghi"].locally_allowed_types,
+            ("Document", "Venue"),
         )
 
     def test_servizi_section(self):
@@ -169,7 +170,10 @@ class TestInitialStructureCreation(unittest.TestCase):
                     ("Document", "Image", "File", "Link"),
                 )
             else:
-                self.assertEqual(child.locally_allowed_types, ("News Item",))
+                self.assertEqual(
+                    child.locally_allowed_types,
+                    ("News Item", "Document", "Image", "File", "Link"),
+                )
 
     def test_documenti_e_dati_section(self):
 
@@ -220,4 +224,7 @@ class TestInitialStructureCreation(unittest.TestCase):
         folder = self.portal["argomenti"]
         self.assertEqual(folder.portal_type, "Document")
         self.assertEqual(folder.constrain_types_mode, 1)
-        self.assertEqual(folder.locally_allowed_types, ("Pagina Argomento",))
+        self.assertEqual(
+            folder.locally_allowed_types, ("Document", "Pagina Argomento")
+        )
+

--- a/src/design/plone/policy/utils.py
+++ b/src/design/plone/policy/utils.py
@@ -69,7 +69,10 @@ def folderSubstructureGenerator(title, types=[]):
                 # restrict_types(context=folder, types=("Event",))
                 pass
             else:
-                restrict_types(context=folder, types=("News Item",))
+                restrict_types(
+                    context=folder,
+                    types=("News Item", "Document", "Image", "File", "Link"),
+                )
 
     elif title == "Amministrazione":
         api.content.create(
@@ -83,7 +86,8 @@ def folderSubstructureGenerator(title, types=[]):
             container=tree_root,
         )
         restrict_types(
-            context=tree_root["personale-amministrativo"], types=("Persona",)
+            context=tree_root["personale-amministrativo"],
+            types=("Document", "Persona",),
         )
 
         api.content.create(
@@ -91,7 +95,7 @@ def folderSubstructureGenerator(title, types=[]):
         )
         restrict_types(
             context=tree_root["organi-di-governo"],
-            types=("UnitaOrganizzativa",),
+            types=("Document", "UnitaOrganizzativa",),
         )
 
         api.content.create(
@@ -99,14 +103,15 @@ def folderSubstructureGenerator(title, types=[]):
         )
         restrict_types(
             context=tree_root["aree-amministrative"],
-            types=("UnitaOrganizzativa",),
+            types=("Document", "UnitaOrganizzativa",),
         )
 
         api.content.create(
             type="Document", title="Uffici", container=tree_root
         )
         restrict_types(
-            context=tree_root["uffici"], types=("UnitaOrganizzativa",)
+            context=tree_root["uffici"],
+            types=("Document", "UnitaOrganizzativa",),
         )
 
         api.content.create(
@@ -114,16 +119,20 @@ def folderSubstructureGenerator(title, types=[]):
         )
         restrict_types(
             context=tree_root["enti-e-fondazioni"],
-            types=("UnitaOrganizzativa",),
+            types=("Document", "UnitaOrganizzativa",),
         )
 
         api.content.create(
             type="Document", title="Luoghi", container=tree_root
         )
-        restrict_types(context=tree_root["luoghi"], types=("Venue",))
+        restrict_types(
+            context=tree_root["luoghi"], types=("Document", "Venue",)
+        )
 
     elif title == "Argomenti":
-        restrict_types(context=tree_root, types=("Pagina Argomento",))
+        restrict_types(
+            context=tree_root, types=("Document", "Pagina Argomento",)
+        )
 
 
 def restrict_types(context, types):


### PR DESCRIPTION
@luca-bellenghi @pnicolli cosa ne pensate?
Così i redattori hanno un po' più di libertà e posso organizzare i contenuti in più livelli.

Poi nei contenuti con i blocchi, è necessario poter aggiungere immagini e file al loro interno