### PR TITLE
Enable bandi in documenti e dati us17807

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
+- [new] Content type 'Bando' is admitted by default in 'Documenti e dati' folder.
+  [arsenico13]
 - [dev] Fix CI
   [arsenico13]
 

--- a/src/design/plone/policy/profiles/default/metadata.xml
+++ b/src/design/plone/policy/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1200</version>
+  <version>1300</version>
   <dependencies>
     <dependency>profile-plone.restapi:default</dependency>
     <dependency>profile-design.plone.contenttypes:default</dependency>

--- a/src/design/plone/policy/setuphandlers.py
+++ b/src/design/plone/policy/setuphandlers.py
@@ -31,6 +31,7 @@ def post_install(context):
     folderSubstructureGenerator(
         title="Documenti e dati",
         types=(
+            "Bando",
             "CartellaModulistica",
             "Document",
             "Documento",

--- a/src/design/plone/policy/setuphandlers.py
+++ b/src/design/plone/policy/setuphandlers.py
@@ -31,12 +31,12 @@ def post_install(context):
     folderSubstructureGenerator(
         title="Documenti e dati",
         types=(
-            "Document",
-            "Image",
-            "File",
-            "Link",
-            "Documento",
             "CartellaModulistica",
+            "Document",
+            "Documento",
+            "File",
+            "Image",
+            "Link",
         ),
     )
     folderSubstructureGenerator(

--- a/src/design/plone/policy/tests/test_initial_structure.py
+++ b/src/design/plone/policy/tests/test_initial_structure.py
@@ -202,12 +202,13 @@ class TestInitialStructureCreation(unittest.TestCase):
             self.assertEqual(
                 child.locally_allowed_types,
                 (
-                    "Document",
-                    "Image",
-                    "File",
-                    "Link",
-                    "Documento",
+                    "Bando",
                     "CartellaModulistica",
+                    "Document",
+                    "Documento",
+                    "File",
+                    "Image",
+                    "Link",
                 ),
             )
 

--- a/src/design/plone/policy/tests/test_initial_structure.py
+++ b/src/design/plone/policy/tests/test_initial_structure.py
@@ -178,12 +178,13 @@ class TestInitialStructureCreation(unittest.TestCase):
         self.assertEqual(
             folder.locally_allowed_types,
             (
-                "Document",
-                "Image",
-                "File",
-                "Link",
-                "Documento",
+                "Bando",
                 "CartellaModulistica",
+                "Document",
+                "Documento",
+                "File",
+                "Image",
+                "Link",
             ),
         )
         self.assertEqual(

--- a/src/design/plone/policy/tests/test_initial_structure.py
+++ b/src/design/plone/policy/tests/test_initial_structure.py
@@ -175,17 +175,11 @@ class TestInitialStructureCreation(unittest.TestCase):
 
         folder = self.portal["documenti-e-dati"]
         self.assertEqual(folder.constrain_types_mode, 1)
+        allowed_types = ('Bando', 'CartellaModulistica', 'Document',
+                         'Documento', 'File', 'Image', 'Link')
         self.assertEqual(
             folder.locally_allowed_types,
-            (
-                "Bando",
-                "CartellaModulistica",
-                "Document",
-                "Documento",
-                "File",
-                "Image",
-                "Link",
-            ),
+            allowed_types
         )
         self.assertEqual(
             folder.keys(),

--- a/src/design/plone/policy/upgrades.py
+++ b/src/design/plone/policy/upgrades.py
@@ -76,3 +76,14 @@ def to_1200(context):
             logger.info("- {}".format(fixed))
     else:
         logger.info("No items affected.")
+
+
+def to_1300(context):
+    """ This upgrade handles that a type "Bando" is now  addmitted by default
+    inside the folder "Documenti e Dati".
+
+    This method just ADD THE CONTENT TYPE to the current list of types that you
+    can add inside that folder.
+    """
+    pc = api.portal.get_tool(name="portal_catalog")
+    import pdb; pdb.set_trace()

--- a/src/design/plone/policy/upgrades.py
+++ b/src/design/plone/policy/upgrades.py
@@ -88,4 +88,5 @@ def to_1300(context):
     pc = api.portal.get_tool(name="portal_catalog")
     if pc:
         pass
-    import pdb; pdb.set_trace()
+    import pdb
+    pdb.set_trace()

--- a/src/design/plone/policy/upgrades.py
+++ b/src/design/plone/policy/upgrades.py
@@ -86,4 +86,6 @@ def to_1300(context):
     can add inside that folder.
     """
     pc = api.portal.get_tool(name="portal_catalog")
+    if pc:
+        pass
     import pdb; pdb.set_trace()

--- a/src/design/plone/policy/upgrades.zcml
+++ b/src/design/plone/policy/upgrades.zcml
@@ -29,4 +29,13 @@
         handler=".upgrades.to_1200"
         />
   </genericsetup:upgradeSteps>
+  <genericsetup:upgradeSteps
+    source="1200"
+    destination="1300"
+    profile="design.plone.policy:default">
+    <genericsetup:upgradeStep
+        title="Install collective.volto.formsupport"
+        handler=".upgrades.to_1300"
+        />
+  </genericsetup:upgradeSteps>
 </configure>

--- a/src/design/plone/policy/upgrades.zcml
+++ b/src/design/plone/policy/upgrades.zcml
@@ -34,7 +34,7 @@
     destination="1300"
     profile="design.plone.policy:default">
     <genericsetup:upgradeStep
-        title="Install collective.volto.formsupport"
+        title="Enable type 'Bando' inside 'Documenti e dati' folder"
         handler=".upgrades.to_1300"
         />
   </genericsetup:upgradeSteps>

--- a/test_plone52.cfg
+++ b/test_plone52.cfg
@@ -20,7 +20,7 @@ plone.app.caching = 3.0.0a3
 # => Remove once Plone 5.2.2 is released
 plone.namedfile = 5.4.0
 plone.schema = 1.2.1
-plone.app.caching = 3.0.0a3
+
 
 # Fixes show self on listing blocks
 # => Remove once Plone 5.2.2 is released


### PR DESCRIPTION
Ok, questa pr segue la richiesta di avere i Bandi disponibili nella cartella Documenti e dati.

Per la creazione di nuovi siti ok, è super easy.
Esiste anche un upgrade step per chi ha già il prodotto installato.

Cosa fa questo upgrade step?
- AGGIUNGE i Bandi solo nei casi in cui non sia già presente
- NON va a modificare l'attuale lista dei contenuti ammessi
- fa questa modifica solo se trova un contenuto "Document" dal titolo "Documenti e dati".