### PR TITLE
[fix] upgrade to_2000 when site is already Plone 6

### DIFF
--- a/src/design/plone/policy/upgrades.py
+++ b/src/design/plone/policy/upgrades.py
@@ -198,8 +198,8 @@ def to_2000(context):  # noqa: C901
             forms.append("site root")
             portal.blocks = json.dumps(portal_blocks)
     except TypeError:
-        # This happens when the site was already Plone 6 and the blocks field
-        # is already an object.
+        # This happens when the site was already Plone 6
+        # and the blocks field is already a dictionary.
         # Since it's Plone 6, the site root will be in the catalog query below,
         # so just skip this step.
         pass

--- a/src/design/plone/policy/upgrades.py
+++ b/src/design/plone/policy/upgrades.py
@@ -191,11 +191,18 @@ def to_2000(context):  # noqa: C901
 
     # fix root
     portal = api.portal.get()
-    portal_blocks = json.loads(portal.blocks)
-    res = fix_block(portal_blocks)
-    if res:
-        forms.append("site root")
-        portal.blocks = json.dumps(portal_blocks)
+    try:
+        portal_blocks = json.loads(portal.blocks)
+        res = fix_block(portal_blocks)
+        if res:
+            forms.append("site root")
+            portal.blocks = json.dumps(portal_blocks)
+    except TypeError:
+        # This happens when the site was already Plone 6 and the blocks field
+        # is already an object.
+        # Since it's Plone 6, the site root will be in the catalog query below,
+        # so just skip this step.
+        pass
 
     # fix blocks in contents
     pc = api.portal.get_tool(name="portal_catalog")

--- a/src/design/plone/policy/utils.py
+++ b/src/design/plone/policy/utils.py
@@ -32,7 +32,7 @@ TASSONOMIA_DOCUMENTI = [
     "Documenti attività politica",
     "Documenti (tecnici) di supporto",
     "Istanze",
-    "Documenti di programmazione e rendicontazione"
+    "Documenti di programmazione e rendicontazione",
     "Dataset",
 ]
 


### PR DESCRIPTION
Il problema è nato perché avevo un sito già Plone 6 (mi pare beta 1) creato un paio di mesi fa, quando mi sono trovato a fare l'upgrade step to_2000.
`portal.blocks` non è una stringa in Plone 6, è già un dizionario, questa PR punta a gestire questo caso, per quanto remoto.