### PR TITLE
forceauth

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 5.0.1 (unreleased)
 ------------------
 
+- Add X-ForceAuth header and iw.rejectanonymous
+  [mamico]
 - Customize Access inactive portal content permission to allow access these contents also for not manager users.
   [cekk]
 

--- a/README.rst
+++ b/README.rst
@@ -248,6 +248,14 @@ e poi lanciare il buildout con ``bin/buildout``.
 
 Successivamente va installato dal pannello di controllo di Plone.
 
+Forzare autenticazione
+----------------------
+
+Se le richieste arrivano con un header X-ForceAuth Plone forza l'autenticazione per quelle richieste,
+il meccanismo è utile ad esempiop se si vuole fare accedere alla ZMI o alle interfacce Plone legacy
+senza però esporle pubblicamente.
+
+
 Test con Volto standalone
 -------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         "redturtle.voltoplugin.editablefooter",
         "redturtle.faq",
         "redturtle.rssservice",
+        "iw.rejectanonymous",
     ],
     extras_require={
         "test": [
@@ -81,7 +82,5 @@ setup(
     entry_points="""
     [z3c.autoinclude.plugin]
     target = plone
-    [console_scripts]
-    update_locale = design.plone.policy.locales.update:update_locale
     """,
 )

--- a/src/design/plone/policy/configure.zcml
+++ b/src/design/plone/policy/configure.zcml
@@ -43,4 +43,10 @@
       name="design.plone.policy-hiddenprofiles"
       />
 
+  <subscriber
+      handler=".rejectanonymous.insertRejectAnonymousHook"
+      for="Products.CMFCore.interfaces.ISiteRoot
+          zope.traversing.interfaces.IBeforeTraverseEvent"
+  />
+
 </configure>

--- a/src/design/plone/policy/configure.zcml
+++ b/src/design/plone/policy/configure.zcml
@@ -44,9 +44,9 @@
       />
 
   <subscriber
-      handler=".rejectanonymous.insertRejectAnonymousHook"
       for="Products.CMFCore.interfaces.ISiteRoot
-          zope.traversing.interfaces.IBeforeTraverseEvent"
-  />
+           zope.traversing.interfaces.IBeforeTraverseEvent"
+      handler=".rejectanonymous.insertRejectAnonymousHook"
+      />
 
 </configure>

--- a/src/design/plone/policy/rejectanonymous.py
+++ b/src/design/plone/policy/rejectanonymous.py
@@ -4,5 +4,5 @@ from iw.rejectanonymous import rejectAnonymous
 
 def insertRejectAnonymousHook(portal, event):
     """force authentication for request with X-ForceAuth header"""
-    if event.request.getHeader('X-ForceAuth'):
+    if event.request.getHeader("X-ForceAuth"):
         event.request.post_traverse(rejectAnonymous, (portal, event.request))

--- a/src/design/plone/policy/rejectanonymous.py
+++ b/src/design/plone/policy/rejectanonymous.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+from iw.rejectanonymous import rejectAnonymous
+
+
+def insertRejectAnonymousHook(portal, event):
+    """force authentication for request with X-ForceAuth header"""
+    if event.request.getHeader('X-ForceAuth'):
+        event.request.post_traverse(rejectAnonymous, (portal, event.request))


### PR DESCRIPTION
Se le richieste arrivano con un header X-ForceAuth Plone forza l'autenticazione per quelle richieste,
il meccanismo è utile ad esempiop se si vuole fare accedere alla ZMI o alle interfacce Plone legacy
senza però esporle pubblicamente.