### PR TITLE
Honor types not searched in search filters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 5.0.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not return section children in @search-filters endpoint if they are types omitted from search results.
+  [cekk]
 
 
 5.0.6 (2023-08-29)

--- a/src/design/plone/policy/restapi/search_filters/get.py
+++ b/src/design/plone/policy/restapi/search_filters/get.py
@@ -44,7 +44,7 @@ class SearchFiltersGet(Service):
         utils = getToolByName(self.context, "plone_utils")
 
         sections = []
-        for setting in json.loads(settings):
+        for setting in json.loads(settings or "[]"):
             items = []
             for section_settings in setting.get("items") or []:
                 for uid in section_settings.get("linkUrl") or []:

--- a/src/design/plone/policy/restapi/search_filters/get.py
+++ b/src/design/plone/policy/restapi/search_filters/get.py
@@ -38,12 +38,8 @@ class SearchFiltersGet(Service):
         return sorted(types, key=lambda k: k["label"])
 
     def reply(self):
-        settings = (
-            api.portal.get_registry_record(
-                "search_sections",
-                interface=IDesignPloneSettings,
-            )
-            or "[]"
+        settings = api.portal.get_registry_record(
+            "search_sections", interface=IDesignPloneSettings, default="[]"
         )
         utils = getToolByName(self.context, "plone_utils")
 

--- a/src/design/plone/policy/restapi/search_filters/get.py
+++ b/src/design/plone/policy/restapi/search_filters/get.py
@@ -6,6 +6,7 @@ from plone.registry.interfaces import IRegistry
 from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.services import Service
 from Products.CMFPlone.interfaces import ISearchSchema
+from Products.CMFCore.utils import getToolByName
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.i18n import translate
@@ -37,47 +38,50 @@ class SearchFiltersGet(Service):
         return sorted(types, key=lambda k: k["label"])
 
     def reply(self):
-        settings = api.portal.get_registry_record(
-            "search_sections",
-            interface=IDesignPloneSettings,
+        settings = (
+            api.portal.get_registry_record(
+                "search_sections",
+                interface=IDesignPloneSettings,
+            )
+            or "[]"
         )
+        utils = getToolByName(self.context, "plone_utils")
+
         sections = []
-        if settings:
-            settings = json.loads(settings)
-            for setting in settings:
-                items = []
-                for section_settings in setting.get("items") or []:
-                    for uid in section_settings.get("linkUrl") or []:
-                        try:
-                            section = api.content.get(UID=uid)
-                        except Unauthorized:
-                            # private folder
-                            continue
-                        if section:
-                            item_infos = getMultiAdapter(
-                                (section, self.request),
-                                ISerializeToJsonSummary,
-                            )()
-                            children = section.listFolderContents()
-                            if children:
-                                item_infos["items"] = []
-                                for children in section.listFolderContents():
-                                    item_infos["items"].append(
-                                        getMultiAdapter(
-                                            (children, self.request),
-                                            ISerializeToJsonSummary,
-                                        )()
-                                    )
-                            if section_settings.get("title", ""):
-                                item_infos["title"] = section_settings["title"]
-                            items.append(item_infos)
-                if items:
-                    sections.append(
-                        {
-                            "rootPath": setting.get("rootPath", ""),
-                            "items": items,
-                        }
+        for setting in json.loads(settings):
+            items = []
+            for section_settings in setting.get("items") or []:
+                for uid in section_settings.get("linkUrl") or []:
+                    try:
+                        section = api.content.get(UID=uid)
+                    except Unauthorized:
+                        # private folder
+                        continue
+                    if not section:
+                        continue
+                    item_infos = getMultiAdapter(
+                        (section, self.request),
+                        ISerializeToJsonSummary,
+                    )()
+                    children = section.listFolderContents(
+                        contentFilter={"portal_type": utils.getUserFriendlyTypes()}
                     )
+                    item_infos["items"] = [
+                        getMultiAdapter(
+                            (x, self.request),
+                            ISerializeToJsonSummary,
+                        )()
+                        for x in children
+                    ]
+                    item_infos["title"] = section_settings.get("title", "")
+                    items.append(item_infos)
+            if items:
+                sections.append(
+                    {
+                        "rootPath": setting.get("rootPath", ""),
+                        "items": items,
+                    }
+                )
         topics = [
             getMultiAdapter(
                 (brain, self.request),


### PR DESCRIPTION
For example if there is a child of "Amministrazione" that is a search excluded type (ie Subsite), we don't want to show it in the filters.