### PR TITLE
Expanditems

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,10 @@ Changelog
 5.0.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- `search_sections` in IDesignPloneSettings has a new filed in each section:
+  `expandItems` that is a boolean to decide if the items of the section should 
+  be expanded or not (default is True).
+  [mamico]
 
 5.0.9 (2024-04-12)
 ------------------

--- a/src/design/plone/policy/restapi/search_filters/get.py
+++ b/src/design/plone/policy/restapi/search_filters/get.py
@@ -42,7 +42,7 @@ class SearchFiltersGet(Service):
             "search_sections", interface=IDesignPloneSettings, default="[]"
         )
         utils = getToolByName(self.context, "plone_utils")
-
+            
         sections = []
         for setting in json.loads(settings or "[]"):
             items = []
@@ -59,16 +59,25 @@ class SearchFiltersGet(Service):
                         (section, self.request),
                         ISerializeToJsonSummary,
                     )()
-                    children = section.listFolderContents(
-                        contentFilter={"portal_type": utils.getUserFriendlyTypes()}
-                    )
-                    item_infos["items"] = [
-                        getMultiAdapter(
-                            (x, self.request),
-                            ISerializeToJsonSummary,
-                        )()
-                        for x in children
-                    ]
+                    if setting.get("expandItems", True):
+                        children = section.listFolderContents(
+                            contentFilter={"portal_type": utils.getUserFriendlyTypes()}
+                        )
+                        item_infos["items"] = [
+                            getMultiAdapter(
+                                (x, self.request),
+                                ISerializeToJsonSummary,
+                            )()
+                            for x in children
+                        ]
+                    else:
+                        # do not expand childrens, the only item is the section/container itself
+                        item_infos["items"] = [
+                            getMultiAdapter(
+                                (section, self.request),
+                                ISerializeToJsonSummary,
+                            )()
+                        ]
                     item_infos["title"] = section_settings.get("title", "")
                     items.append(item_infos)
             if items:

--- a/src/design/plone/policy/restapi/search_filters/get.py
+++ b/src/design/plone/policy/restapi/search_filters/get.py
@@ -59,7 +59,7 @@ class SearchFiltersGet(Service):
                         (section, self.request),
                         ISerializeToJsonSummary,
                     )()
-                    if setting.get("expandItems", True):
+                    if section_settings.get("expandItems", True):
                         children = section.listFolderContents(
                             contentFilter={"portal_type": utils.getUserFriendlyTypes()}
                         )

--- a/src/design/plone/policy/restapi/search_filters/get.py
+++ b/src/design/plone/policy/restapi/search_filters/get.py
@@ -42,7 +42,7 @@ class SearchFiltersGet(Service):
             "search_sections", interface=IDesignPloneSettings, default="[]"
         )
         utils = getToolByName(self.context, "plone_utils")
-            
+
         sections = []
         for setting in json.loads(settings or "[]"):
             items = []

--- a/src/design/plone/policy/tests/test_search_filters_api.py
+++ b/src/design/plone/policy/tests/test_search_filters_api.py
@@ -10,7 +10,8 @@ from plone.restapi.testing import RelativeSession
 from Products.CMFPlone.interfaces import ISearchSchema
 from transaction import commit
 from zope.component import getUtility
-
+from design.plone.contenttypes.controlpanels.settings import IDesignPloneSettings
+import json
 import unittest
 
 
@@ -126,3 +127,18 @@ class SearchFiltersAPITest(unittest.TestCase):
 
         self.assertEqual("Amministrazione", amministrazione["title"])
         self.assertEqual(7, len(amministrazione["items"]))
+
+    def test_not_expand_items(self):
+        # first section has 7 children
+        response = self.api_session.get("/@search-filters").json()
+        self.assertEqual(len(response['sections'][0]['items'][0]['items']), 7)
+
+        # change expandItems to False for the first section
+        settings = json.loads(api.portal.get_registry_record("search_sections",interface=IDesignPloneSettings))
+        settings[0]['expandItems'] = False
+        api.portal.set_registry_record('search_sections', json.dumps(settings), interface=IDesignPloneSettings)
+        commit()
+
+        # first section now has only 1 child
+        response = self.api_session.get("/@search-filters").json()
+        self.assertEqual(len(response['sections'][0]['items'][0]['items']), 1)

--- a/src/design/plone/policy/tests/test_search_filters_api.py
+++ b/src/design/plone/policy/tests/test_search_filters_api.py
@@ -131,14 +131,20 @@ class SearchFiltersAPITest(unittest.TestCase):
     def test_not_expand_items(self):
         # first section has 7 children
         response = self.api_session.get("/@search-filters").json()
-        self.assertEqual(len(response['sections'][0]['items'][0]['items']), 7)
+        self.assertEqual(len(response["sections"][0]["items"][0]["items"]), 7)
 
         # change expandItems to False for the first section
-        settings = json.loads(api.portal.get_registry_record("search_sections",interface=IDesignPloneSettings))
-        settings[0]['expandItems'] = False
-        api.portal.set_registry_record('search_sections', json.dumps(settings), interface=IDesignPloneSettings)
+        settings = json.loads(
+            api.portal.get_registry_record(
+                "search_sections", interface=IDesignPloneSettings
+            )
+        )
+        settings[0]["expandItems"] = False
+        api.portal.set_registry_record(
+            "search_sections", json.dumps(settings), interface=IDesignPloneSettings
+        )
         commit()
 
         # first section now has only 1 child
         response = self.api_session.get("/@search-filters").json()
-        self.assertEqual(len(response['sections'][0]['items'][0]['items']), 1)
+        self.assertEqual(len(response["sections"][0]["items"][0]["items"]), 1)

--- a/src/design/plone/policy/tests/test_search_filters_api.py
+++ b/src/design/plone/policy/tests/test_search_filters_api.py
@@ -132,6 +132,7 @@ class SearchFiltersAPITest(unittest.TestCase):
         # first section has 7 children
         response = self.api_session.get("/@search-filters").json()
         self.assertEqual(len(response["sections"][0]["items"][0]["items"]), 7)
+        self.assertEqual(len(response["sections"][0]["items"][1]["items"]), 15)
 
         # change expandItems to False for the first section
         settings = json.loads(
@@ -139,12 +140,14 @@ class SearchFiltersAPITest(unittest.TestCase):
                 "search_sections", interface=IDesignPloneSettings
             )
         )
-        settings[0]["expandItems"] = False
+        settings[0]["items"][0]["expandItems"] = False
         api.portal.set_registry_record(
             "search_sections", json.dumps(settings), interface=IDesignPloneSettings
         )
         commit()
 
-        # first section now has only 1 child
         response = self.api_session.get("/@search-filters").json()
+        # first item now has only 1 child
         self.assertEqual(len(response["sections"][0]["items"][0]["items"]), 1)
+        # second item still has 15 children
+        self.assertEqual(len(response["sections"][0]["items"][1]["items"]), 15)


### PR DESCRIPTION
`search_sections` in IDesignPloneSettings has a new filed in each section: `expandItems` that is a boolean to decide if the items of the section should be expanded or not (default is True).

The problem he intends to solve is that if a section in the search filters with lots of sub-elements is chosen, those then get exploded in the search pages, also triggering errors like 'too-long-url'