### PR TITLE
Fix volto.formsupport path to not alter returned data on POST.

### DIFF
--- a/src/design/plone/policy/tests/test_limit_submit_form.py
+++ b/src/design/plone/policy/tests/test_limit_submit_form.py
@@ -115,7 +115,7 @@ class TestLimitMailStore(unittest.TestCase):
         )
         transaction.commit()
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.json()["data"]["waiting_list"])
+        self.assertTrue(response.json()["waiting_list"])
 
     def test_unique_field(self):
         self.document.blocks = {

--- a/test_plone60.cfg
+++ b/test_plone60.cfg
@@ -81,3 +81,7 @@ importlib-metadata = 5.2.0
 # Added by buildout at 2023-03-01 12:57:48.164146
 coverage = 7.0.5
 createcoverage = 1.5
+
+# temporary version
+collective.taxonomy = 3.1.5
+collective.volto.blocksfield = 2.2.0


### PR DESCRIPTION
The problem was that with enabled "store data" flag, the patch changed the POST response data structure, and the frontend cannot read submitted data for the thank-you page:

Standard response:

```
{
 "data": {....}
}
```

Response with store data flag:

```
{
  "data": {
    "form_data": {...}
}
```

With this pr we don't change where the data is stored, so frontend will always get it.

This is related to https://github.com/italia/design-comuni-plone-theme/pull/192