### PR TITLE
Fix description

### DIFF
--- a/src/design/plone/policy/__init__.py
+++ b/src/design/plone/policy/__init__.py
@@ -15,8 +15,8 @@ apply()
 
 def initialize(context):
     """Be sure that we have our translations loaded before the othe ones
-       Fix proposto da @alert dell'ordine delle traduzioni preso da
-       https://community.plone.org/t/overriding-plone-app-locales/12021/14
+    Fix proposto da @alert dell'ordine delle traduzioni preso da
+    https://community.plone.org/t/overriding-plone-app-locales/12021/14
     """
     translation_domain = queryUtility(ITranslationDomain, "plone")
     if not translation_domain:

--- a/src/design/plone/policy/__init__.py
+++ b/src/design/plone/policy/__init__.py
@@ -3,6 +3,28 @@
 
 from .sensitive import apply
 from zope.i18nmessageid import MessageFactory
+from zope.i18n.interfaces import ITranslationDomain
+from zope.component import queryUtility
+import logging
+
+logger = logging.getLogger(__name__)
 
 _ = MessageFactory("design.plone.policy")
 apply()
+
+
+def initialize(context):
+    """Be sure that we have our translations loaded before the othe ones"""
+    translation_domain = queryUtility(ITranslationDomain, "plone")
+    if not translation_domain:
+        return
+
+    for lang in translation_domain._catalogs:
+        original = translation_domain._catalogs[lang]
+        # This will enforce our translations to be at the top of the list
+        tweaked = sorted(
+            original, key=lambda path: "design/plone/policy/locales" not in path
+        )
+        if tweaked != original:
+            logger.warning("Boosting this package translations")
+            translation_domain._catalogs[lang] = tweaked

--- a/src/design/plone/policy/__init__.py
+++ b/src/design/plone/policy/__init__.py
@@ -14,7 +14,10 @@ apply()
 
 
 def initialize(context):
-    """Be sure that we have our translations loaded before the othe ones"""
+    """Be sure that we have our translations loaded before the othe ones
+       Fix proposto da @alert dell'ordine delle traduzioni preso da
+       https://community.plone.org/t/overriding-plone-app-locales/12021/14
+    """
     translation_domain = queryUtility(ITranslationDomain, "plone")
     if not translation_domain:
         return

--- a/src/design/plone/policy/configure.zcml
+++ b/src/design/plone/policy/configure.zcml
@@ -4,7 +4,10 @@
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:plone="http://namespaces.plone.org/plone"
     i18n_domain="design.plone.policy"
+    xmlns:five="http://namespaces.zope.org/five"
     >
+
+  <five:registerPackage package="." initialize=".initialize" />
 
   <i18n:registerTranslations directory="locales" />
 

--- a/src/design/plone/policy/configure.zcml
+++ b/src/design/plone/policy/configure.zcml
@@ -1,13 +1,18 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:five="http://namespaces.zope.org/five"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:plone="http://namespaces.plone.org/plone"
     i18n_domain="design.plone.policy"
-    xmlns:five="http://namespaces.zope.org/five"
     >
 
-  <five:registerPackage package="." initialize=".initialize" />
+  <!-- Fix dell'ordine delle traduzioni preso da
+  https://community.plone.org/t/overriding-plone-app-locales/12021/14 -->
+  <five:registerPackage
+      package="."
+      initialize=".initialize"
+      />
 
   <i18n:registerTranslations directory="locales" />
 


### PR DESCRIPTION
Fixed an import order issue for the change of an italian override for the "label_description" field for all content types. Now it is "Descrizione breve" instead of "Descrizione"