### PR TITLE
Clean disable_searchable_types in order to install design.plone.policy on Plone 6.1 and 6.2

### DIFF
--- a/src/design/plone/policy/setuphandlers.py
+++ b/src/design/plone/policy/setuphandlers.py
@@ -86,6 +86,10 @@ def disable_searchable_types(context=None):
         "Pratica",
         "RicevutaPagamento",
     ]
+    fti = api.portal.get_tool("portal_types")
+    for portal_type in remove_types:
+        if portal_type not in fti:
+            remove_types.remove(portal_type)
     types = set(settings.types_not_searched)
     types.update(remove_types)
     settings.types_not_searched = tuple(types)


### PR DESCRIPTION
In plone 6.2 I can't see "Discussion Item" in the portal_types tool; so we can add a check to verify if the type exist before remove it from searchable types